### PR TITLE
Disable keep-alives on servers during shutdown.

### DIFF
--- a/endless.go
+++ b/endless.go
@@ -347,6 +347,8 @@ func (srv *endlessServer) shutdown() {
 	if DefaultHammerTime >= 0 {
 		go srv.hammerTime(DefaultHammerTime)
 	}
+	// disable keep-alives on existing connections
+	srv.SetKeepAlivesEnabled(false)
 	err := srv.EndlessListener.Close()
 	if err != nil {
 		log.Println(syscall.Getpid(), "Listener.Close() error:", err)


### PR DESCRIPTION
Keep-alive connections get their timeouts reset w/each new request made on the connection.
As a result, they can stay open indefinitely, as long as they remain in use.

Disabling keep-alive on shutdown should help ensure that existing connections get cleared out
in a timely fashion.
