### PR TITLE
fix for issue #7

### DIFF
--- a/endless.go
+++ b/endless.go
@@ -503,6 +503,9 @@ type endlessConn struct {
 }
 
 func (w endlessConn) Close() error {
-	w.server.wg.Done()
-	return w.Conn.Close()
+    err := w.Conn.Close()
+    if err == nil {
+        w.server.wg.Done()
+    }
+    return err
 }


### PR DESCRIPTION
As in my previous investigation and code that reproduces the issue, the problem is caused by a second call to endlessConn.Close() of the same connection. net.Conn.Close() will return an error. But wg.Done()  wrongfully reduces the counter and eventually crashes the whole application.

So the fix is simple. 

We check if the connection is already closed before we call wg.Done(). And we make use of the return value of net.Conn.Close() as it will return an error of "use of closed network connection" when we try to call Close on it and it's already closed.
