### PR TITLE
[fix]: extra wg.Done run before running wg.Wait

### DIFF
--- a/endless.go
+++ b/endless.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -403,6 +404,7 @@ func (srv *endlessServer) hammerTime(d time.Duration) {
 			break
 		}
 		srv.wg.Done()
+		runtime.Gosched()
 	}
 }
 

--- a/endless.go
+++ b/endless.go
@@ -2,6 +2,7 @@ package endless
 
 import (
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -410,11 +411,12 @@ func (srv *endlessServer) hammerTime(d time.Duration) {
 
 func (srv *endlessServer) fork() (err error) {
 	// only one server isntance should fork!
+	if runningServersForked {
+		return errors.New("another fork is running")
+	}
 	runningServerReg.Lock()
 	defer runningServerReg.Unlock()
-	if runningServersForked {
-		return
-	}
+
 	runningServersForked = true
 
 	var files = make([]*os.File, len(runningServers))


### PR DESCRIPTION
Call runtime.Gosched() to allow waitgroup.Wait to run when on hammerTime.
