### PR TITLE
runningServersForked should be read with runningServerReg held

### DIFF
--- a/endless.go
+++ b/endless.go
@@ -416,12 +416,13 @@ func (srv *endlessServer) hammerTime(d time.Duration) {
 }
 
 func (srv *endlessServer) fork() (err error) {
+	runningServerReg.Lock()
+	defer runningServerReg.Unlock()
+	
 	// only one server isntance should fork!
 	if runningServersForked {
 		return errors.New("Another process already forked. Ignoring this one.")
 	}
-	runningServerReg.Lock()
-	defer runningServerReg.Unlock()
 
 	runningServersForked = true
 


### PR DESCRIPTION
The current code in `fork()` is racy in the sense that two concurrent go routines might call fork() at the same time, see that runningServersForked is false and perform two forks. Holding runningServerReg makes sure that only one of the goroutines will see runningServersForked set to false.
