### PR TITLE
Ability to save pid file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ If you want to save actual pid file, you can change the `BeforeBegin` hook like 
 	server := endless.NewServer("localhost:4242", handler)
 	server.BeforeBegin = func(add string) {
 		pidfile.SetPidfilePath("actual.pid")
-		pidfile.Write()
+		err := pidfile.Write()
+		if err != nil {
+			log.Println("Cannot write pid file: ", err)
+			os.Exit(-1)
+		}
 		// log.Printf("Pid %d written to actual.pid", syscall.Getpid())
 	}
 	err := server.ListenAndServe()

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you want to save actual pid file, you can change the `BeforeBegin` hook like 
 	server := endless.NewServer("localhost:4242", handler)
 	server.BeforeBegin = func(add string) {
 		log.Printf("Actual pid is %d", syscall.Getpid())
+		// save it somehow
 	}
 	err := server.ListenAndServe()
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to save actual pid file, you can change the `BeforeBegin` hook like 
 	server.BeforeBegin = func(add string) {
 		pidfile.SetPidfilePath("actual.pid")
 		pidfile.Write()
-		// log.Printf("Pid %d written to server.pid", syscall.Getpid())
+		// log.Printf("Pid %d written to actual.pid", syscall.Getpid())
 	}
 	err := server.ListenAndServe()
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Currently you cannot restart a server on a different port than the previous vers
 
 If you want to save actual pid file, you can change the `BeforeBegin` hook like this:
 
+	import "github.com/facebookgo/pidfile"
+
 	server := endless.NewServer("localhost:4242", handler)
 	server.BeforeBegin = func(add string) {
 		pidfile.SetPidfilePath("actual.pid")

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ You can hook your own functions to be called *pre* or *post* signal handling - e
 
 Currently you cannot restart a server on a different port than the previous version was running on.
 
+## PID file
+
+If you want to save actual pid file, you can change the `BeforeBegin` hook like this:
+
+	server := endless.NewServer("localhost:4242", handler)
+	server.BeforeBegin = func(add string) {
+		pidfile.SetPidfilePath("actual.pid")
+		pidfile.Write()
+		// log.Printf("Pid %d written to server.pid", syscall.Getpid())
+	}
+	err := server.ListenAndServe()
+
 
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -86,17 +86,9 @@ Currently you cannot restart a server on a different port than the previous vers
 
 If you want to save actual pid file, you can change the `BeforeBegin` hook like this:
 
-	import "github.com/facebookgo/pidfile"
-
 	server := endless.NewServer("localhost:4242", handler)
 	server.BeforeBegin = func(add string) {
-		pidfile.SetPidfilePath("actual.pid")
-		err := pidfile.Write()
-		if err != nil {
-			log.Println("Cannot write pid file: ", err)
-			os.Exit(-1)
-		}
-		// log.Printf("Pid %d written to actual.pid", syscall.Getpid())
+		log.Printf("Actual pid is %d", syscall.Getpid())
 	}
 	err := server.ListenAndServe()
 


### PR DESCRIPTION
I needed to save pid to file. It didn't turn out as easy as it sounds.

In many cases the written PID file was incorrect. 

For example: you can try to write pid on init, before ListenAndServe. 

That would be wrong if you try to run the server second time. It says `bind: address already in use`, but anyway writes wrong pid.

You can try to write pid file after ListenAndServe (but you can't do that until first request comes and you need to do it in handles, which is messy code). 

You can try to detect if the original pid is still running. But you might be a child. Then you need to detect if `-continue` flag is passed. Which would fail if `endless` changes the way it runs the child and also relies on undocumented behavoir.

Anyway, any solution would lead to incorrect pid file being written in some cases.

The only correct place to get actual pid is deep inside `endless`:

``` go
log.Println(syscall.Getpid(), srv.Addr)
```

So, I replaced it with more generic (fully backwards compatible):

``` go
srv.BeforeBegin(srv.Addr)
```

which, by default, does exactly the same:

``` go
srv.BeforeBegin = func(addr string) {
    log.Println(syscall.Getpid(), addr)
}
```

but, it can be overridden from _user_ code, like so:

``` go
server := endless.NewServer("localhost:4242", handler)
server.BeforeBegin = func(add string) {
    log.Printf("Actual pid is %d", syscall.Getpid())
    // save it somehow
}
err := server.ListenAndServe()
```

So that now user can always have real actual pid in pid file.

Thanks for the awesome library!
