### PR TITLE
change to log hammer message only when actually hammered

### DIFF
--- a/endless.go
+++ b/endless.go
@@ -408,6 +408,9 @@ func (srv *endlessServer) hammerTime(d time.Duration) {
 		return
 	}
 	time.Sleep(d)
+	if srv.getState() == STATE_TERMINATE {
+		return
+	}
 	log.Println("[STOP - Hammer Time] Forcefully shutting down parent")
 	for {
 		if srv.getState() == STATE_TERMINATE {


### PR DESCRIPTION
Change to log hammer message only when actually hammered. Before this change, hammer message is confusing when parent process  is already STATE_TERMINATE and doing another job after Serve. 